### PR TITLE
protect against out of range error.

### DIFF
--- a/lib/grouped_list.dart
+++ b/lib/grouped_list.dart
@@ -355,9 +355,15 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
       }
     }
     var index = math.max(int.parse(topItemKey), 0);
-    if (index != _topElementIndex) {
+    if (index != _topElementIndex) {      
       var curr = widget.groupBy(_sortedElements[index]);
-      var prev = widget.groupBy(_sortedElements[_topElementIndex]);
+      var prev;
+
+      try {
+        prev = widget.groupBy(_sortedElements[_topElementIndex]);
+      } on RangeError catch (_) {
+        prev = widget.groupBy(_sortedElements[0]);
+      }
 
       if (prev != curr) {
         _topElementIndex = index;


### PR DESCRIPTION
It looks like the out-of-range error that was described in #77 managed to creep back into the code.  This pull request addresses the problem.