### PR TITLE
Fixes update to version 3.0 of flutter.

### DIFF
--- a/lib/grouped_list.dart
+++ b/lib/grouped_list.dart
@@ -261,7 +261,7 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
         widget.reverse ? (int i) => i.isOdd : (int i) => i.isEven;
 
     if (widget.reverse) {
-      WidgetsBinding.instance!.addPostFrameCallback((_) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
         _scrollListener();
       });
     }


### PR DESCRIPTION
This change will fix the error when using Flutter 3.0, 

: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
../…/lib/grouped_list.dart:264
- 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../../flutter/packages/flutter/lib/src/widgets/binding.dart').
package:flutter/…/widgets/binding.dart:1
      WidgetsBinding.instance!.addPostFrameCallback((_) {

