### PR TITLE
[bugfix] fix RangeError when _sortedElements is empty

### DIFF
--- a/lib/grouped_list.dart
+++ b/lib/grouped_list.dart
@@ -378,6 +378,10 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
   /// is not required since the group headers are displayed inside the lists and
   /// do not need to be always in the visible frame.
   void _scrollListener() {
+    if (_sortedElements.isEmpty) {
+      return;
+    }
+    
     _listBox ??= _key.currentContext?.findRenderObject() as RenderBox?;
     var listPos = _listBox?.localToGlobal(Offset.zero).dy ?? 0;
     _headerBox ??=


### PR DESCRIPTION
when _sortedElements is empty throw RangeError.

The following RangeError was thrown during a scheduler callback:
RangeError (index): Invalid value: Valid value range is empty: 0

When the exception was thrown, this was the stack: 
#0      List.[] (dart:core-patch/growable_array.dart:264:36)
#1      _GroupedListViewState._scrollListener (package:grouped_list/grouped_list.dart:366:48)
#2      _GroupedListViewState.build.<anonymous closure> (package:grouped_list/grouped_list.dart:272:9)
#3      SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1175:15)
#4      SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1113:9)
#5      SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1015:5)
#6      _invoke (dart:ui/hooks.dart:148:13)
#7      PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:318:5)