### PR TITLE
Feature/distinct key parent child

### DIFF
--- a/example/lib/chat_example.dart
+++ b/example/lib/chat_example.dart
@@ -27,6 +27,8 @@ List<Element> _elements = [
       true),
 ];
 
+GlobalKey _groupListKey = GlobalKey();
+
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
 
@@ -48,6 +50,7 @@ class MyApp extends StatelessWidget {
               SizedBox(
                 height: MediaQuery.of(context).size.height * 0.8,
                 child: GroupedListView<Element, DateTime>(
+                  key: _groupListKey,
                   elements: _elements,
                   order: GroupedListOrder.DESC,
                   reverse: true,

--- a/lib/grouped_list.dart
+++ b/lib/grouped_list.dart
@@ -321,7 +321,6 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
       alignment: Alignment.topCenter,
       children: <Widget>[
         ListView.builder(
-          key: widget.key,
           scrollDirection: widget.scrollDirection,
           controller: _controller,
           primary: widget.primary,


### PR DESCRIPTION
The key of GroupedListView is also used as the key for child ListView, which leads to an exception.
I removed the duplication of key usage in ListView. 