### PR TITLE
fix duplicated group separator if sticky enabled

### DIFF
--- a/lib/grouped_list.dart
+++ b/lib/grouped_list.dart
@@ -19,7 +19,7 @@ class GroupedListView<T, E> extends StatefulWidget {
   /// Items of which [itemBuilder] or [indexedItemBuilder] produce the list.
   final List<T> elements;
 
-  /// Defines which [elements] are grouped together.
+  /// Defines which elements are grouped together.
   ///
   /// Function is called for each element in the list, when equal for two
   /// elements, those two belong to the same group.
@@ -31,15 +31,14 @@ class GroupedListView<T, E> extends StatefulWidget {
   /// specific [Comparable] implementation.
   final int Function(E value1, E value2)? groupComparator;
 
-  /// Can be used to define a custom sorting for the [elements] inside each
-  /// group.
+  /// Can be used to define a custom sorting for the elements inside each group.
   ///
-  /// If not set [elements] will be sorted with their natural sorting order or
+  /// If not set elements will be sorted with their natural sorting order or
   /// their specific [Comparable] implementation.
   final int Function(T element1, T element2)? itemComparator;
 
   /// Called to build group separators for each group.
-  /// Value is always the [groupBy] result from the first element of the group.
+  /// Value is always the groupBy result from the first element of the group.
   ///
   /// Will be ignored if [groupHeaderBuilder] is used.
   final Widget Function(E value)? groupSeparatorBuilder;
@@ -57,31 +56,24 @@ class GroupedListView<T, E> extends StatefulWidget {
 
   /// Called to build children for the list with
   /// 0 <= element, index < elements.length
-  final Widget Function(BuildContext context, T element, int index)?
-      indexedItemBuilder;
-
-  /// This widget is displayed if the list is contains no [elements] and thus is
-  /// empty.
-  ///
-  /// If no defined nothing will be displayed.
-  final Widget? emptyPlaceholder;
+  final Widget Function(BuildContext context, T element, int index)? indexedItemBuilder;
 
   /// Whether the order of the list is ascending or descending.
   ///
-  /// Defaults to [GroupedListOrder.ASC].
+  /// Defaults to ASC.
   final GroupedListOrder order;
 
-  /// Whether the [elements] will be sorted or not. If not it must be done
-  /// manually.
+  /// Whether the elements will be sorted or not. If not it must be done
+  ///  manually.
   ///
-  /// Defauts to `true`.
+  /// Defauts to true.
   final bool sort;
 
-  /// When set to `true` the group header of the current visible group will
-  /// stick on top.
+  /// When set to true the group header of the current visible group will stick
+  ///  on top.
   final bool useStickyGroupSeparators;
 
-  /// Called to build separators for between each element in the list.
+  /// Called to build separators for between each item in the list.
   final Widget separator;
 
   /// Whether the group headers float over the list or occupy their own space.
@@ -176,8 +168,7 @@ class GroupedListView<T, E> extends StatefulWidget {
   ///
   /// See also:
   ///
-  /// * [SemanticsConfiguration.scrollChildCount], the corresponding semantics
-  /// property.
+  ///  * [SemanticsConfiguration.scrollChildCount], the corresponding semantics property.
   final int? semanticChildCount;
 
   /// If non-null, forces the children to have the given extent in the scroll
@@ -189,14 +180,7 @@ class GroupedListView<T, E> extends StatefulWidget {
   /// the scroll position changes drastically.
   final double? itemExtent;
 
-  /// Creates a [GroupedListView].
-  /// This constructor requires that [elements] and [groupBy] are provieded.
-  /// [elements] defines a list of elements which are displayed in the list and
-  /// [groupBy] defindes a function which returns the value on which the
-  /// elements are grouped.
-  ///
-  /// Additionally at least one of [itemBuilder] or [indexedItemBuilder] and one
-  /// of [groupSeparatorBuilder] or [groupHeaderBuilder] must be provieded.
+  /// Creates a [GroupedListView]
   const GroupedListView({
     Key? key,
     required this.elements,
@@ -204,7 +188,6 @@ class GroupedListView<T, E> extends StatefulWidget {
     this.groupComparator,
     this.groupSeparatorBuilder,
     this.groupHeaderBuilder,
-    this.emptyPlaceholder,
     this.itemBuilder,
     this.indexedItemBuilder,
     this.itemComparator,
@@ -289,74 +272,58 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
       });
     }
 
-    /// The itemBuilder function for this package divides the [index] by two
-    /// because between each element a separator is displayed. Depending on the
-    /// direction of the list and if the [index] is even or odd either a item or
-    /// the separator widget is displayed.
-    ///
-    /// If the [index] points to an separator and the previous and next items
-    /// are in different groups, a group header widget is displayed.
-    Widget itemBuilder(context, index) {
-      var actualIndex = index ~/ 2;
-      if (index == hiddenIndex) {
-        return Opacity(
-          opacity: widget.useStickyGroupSeparators ? 0 : 1,
-          child: _buildGroupSeparator(_sortedElements[actualIndex]),
-        );
-      }
-      if (isSeparator(index)) {
-        var curr = widget.groupBy(_sortedElements[actualIndex]);
-        var prev = widget
-            .groupBy(_sortedElements[actualIndex + (widget.reverse ? 1 : -1)]);
-        if (prev != curr) {
-          return _buildGroupSeparator(_sortedElements[actualIndex]);
-        }
-        return widget.separator;
-      }
-      return _buildItem(context, actualIndex);
-    }
-
-    return Stack(
-      key: _key,
-      alignment: Alignment.topCenter,
-      children: <Widget>[
-        ListView.builder(
-          key: widget.key,
-          scrollDirection: widget.scrollDirection,
-          controller: _controller,
-          primary: widget.primary,
-          physics: widget.physics,
-          shrinkWrap: widget.shrinkWrap,
-          padding: widget.padding,
-          reverse: widget.reverse,
-          clipBehavior: widget.clipBehavior,
-          dragStartBehavior: widget.dragStartBehavior,
-          itemExtent: widget.itemExtent,
-          restorationId: widget.restorationId,
-          keyboardDismissBehavior: widget.keyboardDismissBehavior,
-          semanticChildCount: widget.semanticChildCount,
-          itemCount: _sortedElements.length * 2,
-          addAutomaticKeepAlives: widget.addAutomaticKeepAlives,
-          addRepaintBoundaries: widget.addRepaintBoundaries,
-          addSemanticIndexes: widget.addSemanticIndexes,
-          cacheExtent: widget.cacheExtent,
-          itemBuilder: itemBuilder,
-        ),
-        StreamBuilder<int>(
-            stream: _streamController.stream,
-            initialData: _topElementIndex,
-            builder: (context, snapshot) {
-              if (snapshot.hasData) {
-                return _showFixedGroupHeader(snapshot.data!);
-              }
-              return const SizedBox.shrink();
-            }),
-      ],
-    );
+    return StreamBuilder<int>(
+        stream: _streamController.stream,
+        initialData: _topElementIndex,
+        builder: (context, snapshot) {
+          return Stack(
+            key: _key,
+            alignment: Alignment.topCenter,
+            children: <Widget>[
+              ListView.builder(
+                key: widget.key,
+                scrollDirection: widget.scrollDirection,
+                controller: _controller,
+                primary: widget.primary,
+                physics: widget.physics,
+                shrinkWrap: widget.shrinkWrap,
+                padding: widget.padding,
+                reverse: widget.reverse,
+                clipBehavior: widget.clipBehavior,
+                dragStartBehavior: widget.dragStartBehavior,
+                itemExtent: widget.itemExtent,
+                restorationId: widget.restorationId,
+                keyboardDismissBehavior: widget.keyboardDismissBehavior,
+                semanticChildCount: widget.semanticChildCount,
+                itemCount: _sortedElements.length * 2,
+                addAutomaticKeepAlives: widget.addAutomaticKeepAlives,
+                addRepaintBoundaries: widget.addRepaintBoundaries,
+                addSemanticIndexes: widget.addSemanticIndexes,
+                cacheExtent: widget.cacheExtent,
+                itemBuilder: (context, index) {
+                  var actualIndex = index ~/ 2;
+                  if (index == hiddenIndex) {
+                    if (widget.useStickyGroupSeparators) return const SizedBox.shrink();
+                    return _buildGroupSeparator(_sortedElements[actualIndex]);
+                  }
+                  if (isSeparator(index)) {
+                    var curr = widget.groupBy(_sortedElements[actualIndex]);
+                    var prev = widget.groupBy(_sortedElements[actualIndex + (widget.reverse ? 1 : -1)]);
+                    if (prev != curr &&
+                        (!snapshot.hasData || !widget.useStickyGroupSeparators || _sortedElements.isEmpty || snapshot.data != actualIndex)) {
+                      return _buildGroupSeparator(_sortedElements[actualIndex]);
+                    }
+                    return widget.separator;
+                  }
+                  return _buildItem(context, actualIndex);
+                },
+              ),
+              snapshot.hasData ? _showFixedGroupHeader(snapshot.data!) : Container()
+            ],
+          );
+        });
   }
 
-  /// Returns the widget for element positioned at [index]. The widget is
-  /// retrieved either by [widget.indexedItemBuilder] or [widget.itemBuilder].
   Widget _buildItem(context, int index) {
     final key = _keys.putIfAbsent('$index', () => GlobalKey());
     final value = _sortedElements[index];
@@ -368,20 +335,10 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
     );
   }
 
-  /// This scroll listener is added to the lists controller if
-  /// [widget.useStickyGroupSeparators] is `true`. In that case the scroll
-  /// listener keeps track of the top most element which is still in the view
-  /// and saves the elements index in order to be able to display the
-  /// corresponding groupHeader on top of the view.
-  ///
-  /// If the option [widget.useStickyGroupSeparators] is `false` this listener
-  /// is not required since the group headers are displayed inside the lists and
-  /// do not need to be always in the visible frame.
   void _scrollListener() {
     _listBox ??= _key.currentContext?.findRenderObject() as RenderBox?;
     var listPos = _listBox?.localToGlobal(Offset.zero).dy ?? 0;
-    _headerBox ??=
-        _groupHeaderKey?.currentContext?.findRenderObject() as RenderBox?;
+    _headerBox ??= _groupHeaderKey?.currentContext?.findRenderObject() as RenderBox?;
     var headerHeight = _headerBox?.size.height ?? 0;
     var max = double.negativeInfinity;
     var topItemKey = widget.reverse ? '${_sortedElements.length - 1}' : '0';
@@ -415,12 +372,6 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
     }
   }
 
-  /// Sorts the [widget.elements] according the groups. If
-  /// [widget.groupComparator] is defined, it is used for sorting otherwise the
-  /// natural ordering of [widget.groupBy] is used for sorting.
-  ///
-  /// The elements inside a group are sorted accoring to [widget.itemComparator]
-  /// or their natural order.
   List<T> _sortElements() {
     var elements = [...widget.elements];
     if (widget.sort && elements.isNotEmpty) {
@@ -428,11 +379,9 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
         int? compareResult;
         // compare groups
         if (widget.groupComparator != null) {
-          compareResult =
-              widget.groupComparator!(widget.groupBy(e1), widget.groupBy(e2));
+          compareResult = widget.groupComparator!(widget.groupBy(e1), widget.groupBy(e2));
         } else if (widget.groupBy(e1) is Comparable) {
-          compareResult = (widget.groupBy(e1) as Comparable)
-              .compareTo(widget.groupBy(e2) as Comparable);
+          compareResult = (widget.groupBy(e1) as Comparable).compareTo(widget.groupBy(e2) as Comparable);
         }
         // compare elements inside group
         if (compareResult == null || compareResult == 0) {
@@ -451,12 +400,6 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
     return elements;
   }
 
-  /// Returns the group header [Widget] for the given [topElementIndex].
-  ///
-  /// If the option [widget.useStickyGroupSeparators] is set to `true` a
-  /// [Container] with the group header [Widget] is returned.
-  ///
-  ///  Otherwise an empty [Widget] in form of [SizedBox.shrink] is returned.
   Widget _showFixedGroupHeader(int topElementIndex) {
     _groupHeaderKey = GlobalKey();
     if (widget.useStickyGroupSeparators && _sortedElements.isNotEmpty) {
@@ -470,29 +413,22 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
 
       return Container(
         key: _groupHeaderKey,
-        color:
-            widget.floatingHeader ? null : widget.stickyHeaderBackgroundColor,
+        color: widget.floatingHeader ? null : widget.stickyHeaderBackgroundColor,
         width: widget.floatingHeader ? null : MediaQuery.of(context).size.width,
         child: _buildGroupSeparator(topElement),
       );
     }
-    return const SizedBox.shrink();
+    return Container();
   }
 
-  /// Returns the group header [Widget] for an [element] based on
-  /// [widget.groupHeaderBuilder] or if null on the
-  /// [widget.groupSeparatorBuilder].
+  bool _isListItemRendered(GlobalKey<State<StatefulWidget>> key) {
+    return key.currentContext != null && key.currentContext!.findRenderObject() != null;
+  }
+
   Widget _buildGroupSeparator(T element) {
     if (widget.groupHeaderBuilder == null) {
       return widget.groupSeparatorBuilder!(widget.groupBy(element));
     }
     return widget.groupHeaderBuilder!(element);
-  }
-
-  /// Checks if the list item with the given [key] is currently rendered in the
-  /// view frame.
-  bool _isListItemRendered(GlobalKey<State<StatefulWidget>> key) {
-    return key.currentContext != null &&
-        key.currentContext!.findRenderObject() != null;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grouped_list
 description: A Flutter ListView where the list items can be grouped into sections.
-version: 5.1.2
+version: 5.2.0
 homepage: https://begnis.dev
 repository: https://github.com/Dimibe/grouped_list
 


### PR DESCRIPTION
the sticky group separator and the in-list group separator will appear together when the conditions that makes sticky separator visible fulfilled