### PR TITLE
Fix: Fixed group header now literally fixed to top of list

### DIFF
--- a/lib/grouped_list.dart
+++ b/lib/grouped_list.dart
@@ -386,7 +386,19 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
             initialData: _topElementIndex,
             builder: (context, snapshot) {
               if (snapshot.hasData) {
-                return _showFixedGroupHeader(snapshot.data!);
+                return ListenableBuilder(
+                  listenable: _controller,
+                  builder: (context, child) {
+                    final offset = _controller.offset;
+
+                    return Padding(
+                      padding:
+                          EdgeInsets.only(top: offset < 0 ? offset.abs() : 0),
+                      child: child,
+                    );
+                  },
+                  child: _showFixedGroupHeader(snapshot.data!),
+                );
               }
               return const SizedBox.shrink();
             }),


### PR DESCRIPTION
This is basically fixes the bug happens when we use grouped header and pull to refresh together.



|   Before   |   After    |
|------------|------------|
| https://github.com/user-attachments/assets/3c28a457-e933-430e-bdef-133656e2b5dd | https://github.com/user-attachments/assets/5df409c7-7a43-4b08-86bc-0dc8f0632cc0|

