### PR TITLE
only calling scroll listener when required

### DIFF
--- a/lib/grouped_list.dart
+++ b/lib/grouped_list.dart
@@ -314,9 +314,10 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
     var isSeparator = widget.reverse ? (int i) => i.isOdd : (int i) => i.isEven;
     isValidIndex(int i) => i >= 0 && i < _sortedElements.length;
 
+     if (widget.useStickyGroupSeparators) {
     _ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((_) {
       _scrollListener();
-    });
+    });}
 
     /// The itemBuilder function for this package divides the [index] by two
     /// because between each element a separator is displayed. Depending on the


### PR DESCRIPTION
Getting this error earlier
════════ Exception caught by scheduler library ═════════════════════════════════
The following assertion was thrown during a scheduler callback:
'package:flutter/src/rendering/object.dart': Failed assertion: line 3374 pos 12: 'attached': is not true.

Either the assertion indicates an error in the framework itself, or we should provide substantially more information in this error message to help you determine and fix the underlying cause.
In either case, please report this assertion by filing a bug on GitHub:
  https://github.com/flutter/flutter/issues/new?template=2_bug.yml