### PR TITLE
feat: add emptyPlaceholder support for empty list states

### DIFF
--- a/lib/grouped_list.dart
+++ b/lib/grouped_list.dart
@@ -310,6 +310,12 @@ class _GroupedListViewState<T, E> extends State<GroupedListView<T, E>> {
   @override
   Widget build(BuildContext context) {
     _sortedElements = _sortElements();
+
+    // If the list is empty, try using the emptyPlaceholder; otherwise, just use a SizedBox.
+    if (_sortedElements.isEmpty) {
+      return widget.emptyPlaceholder ?? const SizedBox.shrink();
+    }
+
     var hiddenIndex = widget.reverse ? _sortedElements.length * 2 - 1 : 0;
     var isSeparator = widget.reverse ? (int i) => i.isOdd : (int i) => i.isEven;
     isValidIndex(int i) => i >= 0 && i < _sortedElements.length;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grouped_list
 description: A Flutter ListView where the list items can be grouped into sections.
-version: 6.0.0
+version: 6.0.1
 homepage: https://begnis.dev
 repository: https://github.com/Dimibe/grouped_list
 


### PR DESCRIPTION
Adds a emptyPlaceholder property to allow displaying custom content
when the list is empty.

If an emptyPlaceholder is provided, it will be rendered when no items
are available. Otherwise, a SizedBox will be used as the default empty
state widget.

This improves flexibility for consumers of the package by enabling
custom empty state messages, illustrations, or actions.